### PR TITLE
グラフの種類, 軸の変更

### DIFF
--- a/routes/graph.js
+++ b/routes/graph.js
@@ -11,20 +11,20 @@ exports.showGraph = function(socket){
     model.query('SELECT * FROM member', function(err, rows) {
       var dataPlotMale = [
         { label: "れい",  y: rows[0]["num_of_votes_male"],indexLabel:String(rows[0]["num_of_votes_male"])},
-        { label: "いっちー",y: rows[1]["num_of_votes_male"],indexLabel:String(rows[1]["num_of_votes_male"]) },
+        { label: "いちのき",y: rows[1]["num_of_votes_male"],indexLabel:String(rows[1]["num_of_votes_male"]) },
         { label: "ももか",y: rows[2]["num_of_votes_male"],indexLabel:String(rows[2]["num_of_votes_male"]) },
         { label: "ひるた",y: rows[3]["num_of_votes_male"],indexLabel:String(rows[3]["num_of_votes_male"])},
         { label: "ぼみ", y: rows[4]["num_of_votes_male"],indexLabel:String(rows[4]["num_of_votes_male"]) },
-        { label: "いっしゅー", y: rows[5]["num_of_votes_male"],indexLabel:String(rows[5]["num_of_votes_male"])}
+        { label: "いっしゅう", y: rows[5]["num_of_votes_male"],indexLabel:String(rows[5]["num_of_votes_male"])}
       ];
 
       var dataPlotFemale = [
         { label: "れい",  y: rows[0]["num_of_votes_female"], indexLabel:String(rows[0]["num_of_votes_female"])},
-        { label: "いっちー",y: rows[1]["num_of_votes_female"],indexLabel:String(rows[1]["num_of_votes_female"]) },
+        { label: "いちのき",y: rows[1]["num_of_votes_female"],indexLabel:String(rows[1]["num_of_votes_female"]) },
         { label: "ももか",y: rows[2]["num_of_votes_female"],indexLabel:String(rows[2]["num_of_votes_female"]) },
         { label: "ひるた",y: rows[3]["num_of_votes_female"], indexLabel:String(rows[3]["num_of_votes_female"])},
         { label: "ぼみ", y: rows[4]["num_of_votes_female"],indexLabel:String(rows[4]["num_of_votes_female"]) },
-        { label: "いっしゅー", y: rows[5]["num_of_votes_female"],indexLabel:String(rows[5]["num_of_votes_female"])}
+        { label: "いっしゅう", y: rows[5]["num_of_votes_female"],indexLabel:String(rows[5]["num_of_votes_female"])}
       ];
       //console.log(dataPlotFemale)
       //console.log(dataPlotMale)

--- a/views/graph.ejs
+++ b/views/graph.ejs
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="utf-8">
-    <title>投票結果</title>
+    <title>RESULT</title>
 </head>
 <body>
   <div id="chartContainerMale" style="position: fixed; top: 10%; left:10%;width:80%; height:35%;"></div>
@@ -20,21 +20,28 @@
 
     socket.on('show_graph_male', function(data){
       //console.log(data);
+
       var chart_male = new CanvasJS.Chart("chartContainerMale", {
         title:{
-          text: "MEN"
+          text: "MAN"
         },
         axisY:{
           interlacedColor: "#F8F1E4",
           tickLength: 10,
-          maximum:200
+          maximum:150
         },
+        axisX: {
+              	labelFontSize:20,
+				},
         data: [{
-          type: 'column',
+          type: 'bar',
           indexLabelFontSize: 30,
           dataPoints: data
         }]
       });
+
+
+
       chart_male.render();
     });
 
@@ -43,15 +50,18 @@
       console.log(data);
       var chart_female = new CanvasJS.Chart("chartContainerFemale", {
         title:{
-          text: "LADIES"
+          text: "LADY"
         },
         axisY:{
           interlacedColor: "#F8F1E4",
           tickLength: 10,
-          maximum:200
+          maximum:150
         },
+        axisX: {
+              	labelFontSize:20,
+				},
         data: [{
-          type: 'column',
+          type: 'bar',
           indexLabelFontSize: 30,
           dataPoints: data
         }]


### PR DESCRIPTION
# グラフの種類, 軸の変更
## routes/graph.js
* グラフに表示させる人名をherokuのmemberテーブルのnameに合わせる
  + れい
  + いちのき (「いっちー」 から変更)
  + ももか
  + ひるた
  + ぼみ
  + いっしゅう (「いっしゅー」から変更)
## views/graph.ejs
* titleを投票結果からRESULTに変更
* グラフの種類をcolumn(縦棒グラフ)から bar(横棒グラフ)に変更
* グラフ軸の上限を150に変更
* グラフのタイトルをアプリと同様「MAN」「LADY」に変更

